### PR TITLE
Fix fileprovider build with androidx

### DIFF
--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -37,7 +37,9 @@ android {
         versionCode {{ args.numeric_version }}
         versionName '{{ args.version }}'
         manifestPlaceholders = {{ args.manifest_placeholders}}
+        {%- if args.fileprovider_paths %}
         multiDexEnabled true
+        {%- endif %}
     }
 
 	
@@ -128,7 +130,14 @@ dependencies {
     {% if args.presplash_lottie %}
     implementation 'com.airbnb.android:lottie:3.4.0'
     {%- endif %}
+    {% if args.fileprovider_paths %}
+    {%- if args.enable_androidx -%}
+    implementation 'androidx.core:core:1.8.0'
+    implementation 'androidx.multidex:multidex:2.0.1'
+    {%- else -%}
     implementation 'com.android.support:support-v4:26.1.0'
     implementation 'com.android.support:multidex:1.0.3'
+    {%- endif -%}
+    {% endif %}
 }
 


### PR DESCRIPTION
When androidx is enabled, the android support library is no longer
available. The library artifact needs to be replaced as well as changing
code to use the `FileProvider` class from `androidx.core.content`
instead of `android.support.v4.content`.

Unfortunately, multidex is mixed up in this even though it doesn't have
anything to do FileProvider or general usage of androidx. Keep them
together for now.