### PR TITLE
Resolve absolute path to local recipes

### DIFF
--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -717,7 +717,7 @@ class ToolchainCL:
 
         self._archs = args.arch
 
-        self.ctx.local_recipes = args.local_recipes
+        self.ctx.local_recipes = realpath(args.local_recipes)
         self.ctx.copy_libs = args.copy_libs
 
         self.ctx.activity_class_name = args.activity_class_name


### PR DESCRIPTION
This is necessary when using patches in a local recipe since
`Recipe.apply_patch` assumes the recipe directory is absolute and uses
`patch -d` to change directories. It could just be fixed there, but this
ensures that recipe directories are always absolute.

I came across this while trying to patch zstandard so it didn't need `USE_CCACHE` disabled. I filed this upstream at https://github.com/kivy/python-for-android/issues/2623 but haven't had time to get a proper PR there.