### PR TITLE
Support Google Services and extra Gradle plugins

### DIFF
--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -94,6 +94,8 @@ options (this list may not be exhaustive):
 - ``--enable-google-services``: Enable the Google Services Gradle plugin.
   This option requires a ``google-services.json`` file in root of the
   project directory.
+- ``--add-gradle-plugins``: Add a plugin for gradle. The format of the option
+  is ``<plugin-id>:<classpath>``. The option can be specified multiple times.
 
 
 webview
@@ -158,6 +160,8 @@ ready.
 - ``--enable-google-services``: Enable the Google Services Gradle plugin.
   This option requires a ``google-services.json`` file in root of the
   project directory.
+- ``--add-gradle-plugins``: Add a plugin for gradle. The format of the option
+  is ``<plugin-id>:<classpath>``. The option can be specified multiple times.
 
 
 service_library
@@ -186,6 +190,8 @@ systems and frameworks.
 - ``--enable-google-services``: Enable the Google Services Gradle plugin.
   This option requires a ``google-services.json`` file in root of the
   project directory.
+- ``--add-gradle-plugin``: Add a plugin for gradle. The format of the option
+  is ``<plugin-id>:<classpath>``. The option can be specified multiple times.
 
 
 Requirements blacklist (APK size optimization)

--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -91,6 +91,9 @@ options (this list may not be exhaustive):
 - ``--add-source``: Add a source directory to the app's Java code.
 - ``--no-compile-pyo``: Do not optimise .py files to .pyo.
 - ``--enable-androidx``: Enable AndroidX support library.
+- ``--enable-google-services``: Enable the Google Services Gradle plugin.
+  This option requires a ``google-services.json`` file in root of the
+  project directory.
 
 
 webview
@@ -152,6 +155,9 @@ ready.
 - ``add-source``: Add a source directory to the app's Java code.
 - ``--port``: The port on localhost that the WebView will
   access. Defaults to 5000.
+- ``--enable-google-services``: Enable the Google Services Gradle plugin.
+  This option requires a ``google-services.json`` file in root of the
+  project directory.
 
 
 service_library
@@ -177,6 +183,9 @@ systems and frameworks.
 - ``--add-jar``: The path to a .jar file to include in the APK. To
   include multiple jar files, pass this argument multiple times.
 - ``add-source``: Add a source directory to the app's Java code.
+- ``--enable-google-services``: Enable the Google Services Gradle plugin.
+  This option requires a ``google-services.json`` file in root of the
+  project directory.
 
 
 Requirements blacklist (APK size optimization)

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -548,6 +548,9 @@ main.py that loads it.''')
     if args.fileprovider_paths:
         shutil.copy(args.fileprovider_paths, join(res_dir, "xml/file_paths.xml"))
 
+    if args.enable_google_services:
+        shutil.copy(args.google_services_json, 'src/google-services.json')
+
     # gradle build templates
     render(
         'build.tmpl.gradle',
@@ -864,6 +867,15 @@ tools directory of the Android SDK.
     ap.add_argument('--activity-class-name', dest='activity_class_name', default=DEFAULT_PYTHON_ACTIVITY_JAVA_CLASS,
                     help='The full java class name of the main activity')
 
+    ap.add_argument('--enable-google-services', dest='enable_google_services',
+                    action='store_true',
+                    help=('Enable the Google Services Gradle plugin. '
+                          'This requires a google-services.json in the root '
+                          'of the project.'))
+    ap.add_argument('--google-services-json', dest='google_services_json',
+                    default='google-services.json',
+                    help='Path to google-services.json file')
+
     # Put together arguments, and add those from .p4a config file:
     if args is None:
         args = sys.argv[1:]
@@ -949,6 +961,12 @@ tools directory of the Android SDK.
               '--launcher (SDL2 bootstrap only)' +
               'to have something to launch inside the .apk!')
         sys.exit(1)
+
+    if args.enable_google_services and not exists(args.google_services_json):
+        print('You must provide a google-services.json file for '
+              '--enable-google-services')
+        sys.exit(1)
+
     make_package(args)
 
     return args

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -551,6 +551,13 @@ main.py that loads it.''')
     if args.enable_google_services:
         shutil.copy(args.google_services_json, 'src/google-services.json')
 
+    # Convert the gradle_plugins args to a list of dicts with id and
+    # classpath keys.
+    gradle_plugins = [
+        dict(zip(('id', 'classpath'), spec.split(':', maxsplit=1)))
+        for spec in args.gradle_plugins
+    ]
+
     # gradle build templates
     render(
         'build.tmpl.gradle',
@@ -562,6 +569,7 @@ main.py that loads it.''')
         build_tools_version=build_tools_version,
         debug_build="debug" in args.build_mode,
         is_library=(get_bootstrap_name() == 'service_library'),
+        gradle_plugins=gradle_plugins,
         )
 
     # gradle properties
@@ -764,6 +772,12 @@ tools directory of the Android SDK.
                     default=[],
                     action='append',
                     help='Ddd a repository for gradle')
+    ap.add_argument('--add-gradle-plugin', dest='gradle_plugins',
+                    default=[],
+                    action='append',
+                    help=('Add a plugin for gradle. The format of the option '
+                          'is <plugin-id>:<classpath>. The option can be '
+                          'specified multiple times.'))
     ap.add_argument('--add-packaging-option', dest='packaging_options',
                     default=[],
                     action='append',

--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -9,6 +9,9 @@ buildscript {
         {% if args.enable_google_services %}
         classpath 'com.google.gms:google-services:4.3.14'
         {% endif %}
+        {% for plugin in gradle_plugins %}
+        classpath '{{ plugin.classpath }}'
+        {% endfor %}
     }
 }
 
@@ -33,6 +36,9 @@ apply plugin: 'com.android.application'
 {% if args.enable_google_services %}
 apply plugin: 'com.google.gms.google-services'
 {% endif %}
+{% for plugin in gradle_plugins %}
+apply plugin: '{{ plugin.id }}'
+{% endfor %}
 
 android {
     compileSdkVersion {{ android_api }}

--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -6,6 +6,9 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.1.2'
+        {% if args.enable_google_services %}
+        classpath 'com.google.gms:google-services:4.3.14'
+        {% endif %}
     }
 }
 
@@ -26,6 +29,9 @@ allprojects {
 apply plugin: 'com.android.library'
 {% else %}
 apply plugin: 'com.android.application'
+{% endif %}
+{% if args.enable_google_services %}
+apply plugin: 'com.google.gms.google-services'
 {% endif %}
 
 android {

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -552,6 +552,10 @@ class ToolchainCL:
         parser_packaging.add_argument(
             '--signkeypw', dest='signkeypw', action='store', default=None,
             help='Password for key alias')
+        parser_packaging.add_argument(
+            '--google-services-json', dest='google_services_json',
+            default='google-services.json',
+            help='Path to google-services.json file')
 
         add_parser(
             subparsers,
@@ -627,6 +631,8 @@ class ToolchainCL:
             args.unknown_args += ["--activity-class-name", args.activity_class_name]
         if hasattr(args, "service_class_name") and args.service_class_name != 'org.kivy.android.PythonService':
             args.unknown_args += ["--service-class-name", args.service_class_name]
+        if hasattr(args, "google_services_json") and args.google_services_json:
+            args.unknown_args += ["--google-services-json", args.google_services_json]
 
         self.args = args
 
@@ -990,7 +996,8 @@ class ToolchainCL:
 
         fix_args = ('--dir', '--private', '--add-jar', '--add-source',
                     '--whitelist', '--blacklist', '--presplash', '--icon',
-                    '--icon-bg', '--icon-fg', '--fileprovider-paths')
+                    '--icon-bg', '--icon-fg', '--fileprovider-paths',
+                    '--google-services-json')
         unknown_args = args.unknown_args
 
         for asset in args.assets:


### PR DESCRIPTION
This is untested, but I think it should support our desire for enabling the Google Services and Crashlytics plugins.