### PR TITLE
More manifest and gradle templating

### DIFF
--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -97,6 +97,11 @@ options (this list may not be exhaustive):
   added to the ``<manifest><application>`` tag of AndroidManifest.xml.
 - ``--manifest-placeholders``: Inject build variables into the manifest
   via the ``manifestPlaceholders`` property.
+- ``--debug-manifest-placeholders``: Inject build variables into the
+  manifest via the manifestPlaceholders property in the debug buildType.
+- ``--release-manifest-placeholders``: Inject build variables into the
+  manifest via the manifestPlaceholders property in the release
+  buildType.
 - ``--enable-google-services``: Enable the Google Services Gradle plugin.
   This option requires a ``google-services.json`` file in root of the
   project directory.
@@ -172,6 +177,11 @@ ready.
   added to the ``<manifest><application>`` tag of AndroidManifest.xml.
 - ``--manifest-placeholders``: Inject build variables into the manifest
   via the ``manifestPlaceholders`` property.
+- ``--debug-manifest-placeholders``: Inject build variables into the
+  manifest via the manifestPlaceholders property in the debug buildType.
+- ``--release-manifest-placeholders``: Inject build variables into the
+  manifest via the manifestPlaceholders property in the release
+  buildType.
 - ``--enable-google-services``: Enable the Google Services Gradle plugin.
   This option requires a ``google-services.json`` file in root of the
   project directory.

--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -168,6 +168,8 @@ ready.
   access. Defaults to 5000.
 - ``--extra-manifest-xml``: Extra xml to write directly inside the
   ``<manifest>`` element of AndroidManifest.xml.
+- ``--extra-manifest-application-arguments``: Extra arguments to be
+  added to the ``<manifest><application>`` tag of AndroidManifest.xml.
 - ``--manifest-placeholders``: Inject build variables into the manifest
   via the ``manifestPlaceholders`` property.
 - ``--enable-google-services``: Enable the Google Services Gradle plugin.

--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -91,6 +91,12 @@ options (this list may not be exhaustive):
 - ``--add-source``: Add a source directory to the app's Java code.
 - ``--no-compile-pyo``: Do not optimise .py files to .pyo.
 - ``--enable-androidx``: Enable AndroidX support library.
+- ``--extra-manifest-xml``: Extra xml to write directly inside the
+  ``<manifest>`` element of AndroidManifest.xml.
+- ``--extra-manifest-application-arguments``: Extra arguments to be
+  added to the ``<manifest><application>`` tag of AndroidManifest.xml.
+- ``--manifest-placeholders``: Inject build variables into the manifest
+  via the ``manifestPlaceholders`` property.
 - ``--enable-google-services``: Enable the Google Services Gradle plugin.
   This option requires a ``google-services.json`` file in root of the
   project directory.
@@ -160,6 +166,8 @@ ready.
 - ``add-source``: Add a source directory to the app's Java code.
 - ``--port``: The port on localhost that the WebView will
   access. Defaults to 5000.
+- ``--manifest-placeholders``: Inject build variables into the manifest
+  via the ``manifestPlaceholders`` property.
 - ``--enable-google-services``: Enable the Google Services Gradle plugin.
   This option requires a ``google-services.json`` file in root of the
   project directory.

--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -166,6 +166,8 @@ ready.
 - ``add-source``: Add a source directory to the app's Java code.
 - ``--port``: The port on localhost that the WebView will
   access. Defaults to 5000.
+- ``--extra-manifest-xml``: Extra xml to write directly inside the
+  ``<manifest>`` element of AndroidManifest.xml.
 - ``--manifest-placeholders``: Inject build variables into the manifest
   via the ``manifestPlaceholders`` property.
 - ``--enable-google-services``: Enable the Google Services Gradle plugin.

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -876,6 +876,18 @@ tools directory of the Android SDK.
     ap.add_argument('--manifest-placeholders', dest='manifest_placeholders',
                     default='[:]', help=('Inject build variables into the manifest '
                                          'via the manifestPlaceholders property'))
+    ap.add_argument('--debug-manifest-placeholders',
+                    dest='debug_manifest_placeholders',
+                    default='[:]',
+                    help=('Inject build variables into the manifest '
+                          'via the manifestPlaceholders property '
+                          'in the debug buildType'))
+    ap.add_argument('--release-manifest-placeholders',
+                    dest='release_manifest_placeholders',
+                    default='[:]',
+                    help=('Inject build variables into the manifest '
+                          'via the manifestPlaceholders property '
+                          'in the release buildType'))
     ap.add_argument('--service-class-name', dest='service_class_name', default=DEFAULT_PYTHON_SERVICE_JAVA_CLASS,
                     help='Use that parameter if you need to implement your own PythonServive Java class')
     ap.add_argument('--activity-class-name', dest='activity_class_name', default=DEFAULT_PYTHON_ACTIVITY_JAVA_CLASS,

--- a/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
+++ b/pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle
@@ -94,6 +94,7 @@ android {
 
     buildTypes {
         debug {
+            manifestPlaceholders = {{ args.debug_manifest_placeholders }}
             {% if args.enable_crashlytics_native_symbol_upload -%}
             firebaseCrashlytics {
                 nativeSymbolUploadEnabled true
@@ -105,6 +106,7 @@ android {
             {% if args.sign -%}
             signingConfig signingConfigs.release
             {%- endif %}
+            manifestPlaceholders = {{ args.release_manifest_placeholders }}
             {% if args.enable_crashlytics_native_symbol_upload -%}
             firebaseCrashlytics {
                 nativeSymbolUploadEnabled true

--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -35,6 +35,8 @@
     <uses-permission android:name="com.android.vending.BILLING" />
     {% endif %}
 
+    {{ args.extra_manifest_xml }}
+
     <!-- Create a Java class extending SDLActivity and place it in a
          directory under src matching the package, e.g.
          	src/com/gamemaker/game/MyGame.java

--- a/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/service_only/build/templates/AndroidManifest.tmpl.xml
@@ -53,7 +53,9 @@
                  {% if args.backup_rules %}android:fullBackupContent="@xml/{{ args.backup_rules }}"{% endif %}
                  android:theme="{{args.android_apptheme}}{% if not args.window %}.Fullscreen{% endif %}"
                  android:hardwareAccelerated="true"
-                 android:extractNativeLibs="true" >
+                 android:extractNativeLibs="true"
+                 {{ args.extra_manifest_application_arguments }}
+                 >
         {% for l in args.android_used_libs %}
         <uses-library android:name="{{ l }}" />
         {% endfor %}

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -36,6 +36,8 @@
     <uses-permission android:name="com.android.vending.BILLING" />
     {% endif %}
 
+    {{ args.extra_manifest_xml }}
+
     <!-- Create a Java class extending SDLActivity and place it in a
          directory under src matching the package, e.g.
          	src/com/gamemaker/game/MyGame.java

--- a/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
+++ b/pythonforandroid/bootstraps/webview/build/templates/AndroidManifest.tmpl.xml
@@ -56,6 +56,7 @@
                  android:usesCleartextTraffic="true"
                  android:extractNativeLibs="true"
                  {% if debug %}android:debuggable="true"{% endif %}
+                 {{ args.extra_manifest_application_arguments }}
                  >
         {% for l in args.android_used_libs %}
         <uses-library android:name="{{ l }}" />

--- a/pythonforandroid/recipe.py
+++ b/pythonforandroid/recipe.py
@@ -629,7 +629,7 @@ class Recipe(metaclass=RecipeMeta):
         shprint(sh.cp, *args)
 
     def has_libs(self, arch, *libs):
-        return all(map(lambda l: self.ctx.has_lib(arch.arch, l), libs))
+        return all(map(lambda lib: self.ctx.has_lib(arch.arch, lib), libs))
 
     def get_libraries(self, arch_name, in_context=False):
         """Return the full path of the library depending on the architecture.

--- a/tests/test_pythonpackage_basic.py
+++ b/tests/test_pythonpackage_basic.py
@@ -269,11 +269,15 @@ class TestGetSystemPythonExecutable():
             p2 = os.path.normpath(pybin)
             assert p1 == p2
         except RuntimeError as e:
+            # (remember this is not in a virtualenv)
+            # Some deps may not be installed, so we just avoid to raise
+            # an exception here, as a missing dep should not make the test
+            # fail.
             if "pep517" in str(e.args):
                 # System python probably doesn't have pep517 available!
-                # (remember this is not in a virtualenv)
-                # Not much we can do in that case since pythonpackage needs it,
-                # so we'll skip this particular check.
+                pass
+            elif "toml" in str(e.args):
+                # System python probably doesn't have toml available!
                 pass
             else:
                 raise

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,19 @@ commands = flake8 pythonforandroid/ tests/ ci/ setup.py
 
 [flake8]
 ignore =
-    E123,  # Closing bracket does not match indentation of opening bracket's line
-    E124,  # Closing bracket does not match visual indentation
-    E126,  # Continuation line over-indented for hanging indent
-    E226,  # Missing whitespace around arithmetic operator
-    E402,  # Module level import not at top of file
-    E501,  # Line too long (82 > 79 characters)
-    W503,  # Line break occurred before a binary operator
-    W504   # Line break occurred after a binary operator
+    # Closing bracket does not match indentation of opening bracket's line
+    E123,
+    # Closing bracket does not match visual indentation
+    E124,
+    # Continuation line over-indented for hanging indent
+    E126,
+    # Missing whitespace around arithmetic operator
+    E226,
+    # Module level import not at top of file
+    E402,
+    # Line too long (82 > 79 characters)
+    E501,
+    # Line break occurred before a binary operator
+    W503,
+    # Line break occurred after a binary operator
+    W504


### PR DESCRIPTION
Wire up some more templating in the generated `AndroidManifest.xml` and `build.gradle` files to support some features we want to use. I believe this can all be sent upstream, but I want to get it working downstream first.

Needed for https://github.com/endlessm/kolibri-installer-android/issues/125 and https://github.com/endlessm/kolibri-installer-android/issues/128.