### PR TITLE
Support for resource value files

### DIFF
--- a/doc/source/buildoptions.rst
+++ b/doc/source/buildoptions.rst
@@ -110,6 +110,9 @@ options (this list may not be exhaustive):
 - ``--enable-crashlytics-native-symbol-upload``: Enable processing and uploading
   of native symbols to Firebase servers. This flag must be enabled to see
   properly-symbolicated native stack traces in the Crashlytics dashboard.
+- ``--res-values``: Resource value files to include in the app such as
+  ``colors.xml`` and ``styles.xml``. This option can be specified multiple
+  times.
 
 
 webview
@@ -190,6 +193,9 @@ ready.
 - ``--enable-crashlytics-native-symbol-upload``: Enable processing and uploading
   of native symbols to Firebase servers. This flag must be enabled to see
   properly-symbolicated native stack traces in the Crashlytics dashboard.
+- ``--res-values``: Resource value files to include in the app such as
+  ``colors.xml`` and ``styles.xml``. This option can be specified multiple
+  times.
 
 
 service_library
@@ -220,6 +226,9 @@ systems and frameworks.
   project directory.
 - ``--add-gradle-plugin``: Add a plugin for gradle. The format of the option
   is ``<plugin-id>:<classpath>``. The option can be specified multiple times.
+- ``--res-values``: Resource value files to include in the app such as
+  ``colors.xml`` and ``styles.xml``. This option can be specified multiple
+  times.
 
 
 Requirements blacklist (APK size optimization)

--- a/pythonforandroid/bootstrap.py
+++ b/pythonforandroid/bootstrap.py
@@ -70,7 +70,6 @@ class Bootstrap:
     '''An Android project template, containing recipe stuff for
     compilation and templated fields for APK info.
     '''
-    name = ''
     jni_subdir = '/jni'
     ctx = None
 

--- a/pythonforandroid/bootstraps/common/build/build.py
+++ b/pythonforandroid/bootstraps/common/build/build.py
@@ -522,6 +522,13 @@ main.py that loads it.''')
                 xmlpath = join(args.private, xmlpath)
             shutil.copy(xmlpath, res_xml_dir)
 
+    # Copy res_values files to src/main/res/values
+    res_values_dir = join(res_dir, 'values')
+    if args.res_values:
+        ensure_dir(res_values_dir)
+        for xmlpath in args.res_values:
+            shutil.copy(xmlpath, res_values_dir)
+
     # Render out android manifest:
     manifest_path = "src/main/AndroidManifest.xml"
     render_args = {
@@ -832,6 +839,8 @@ tools directory of the Android SDK.
                           'directory'))
     ap.add_argument('--res_xml', dest='res_xmls', action='append', default=[],
                     help='Add files to res/xml directory (for example device-filters)', nargs='+')
+    ap.add_argument('--res-values', dest='res_values', action='append', default=[],
+                    help='Add files to res/values directory (for example styles.xml)')
     ap.add_argument('--with-billing', dest='billing_pubkey',
                     help='If set, the billing service will be added (not implemented)')
     ap.add_argument('--add-source', dest='extra_source_dirs', action='append',

--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -77,11 +77,6 @@ class Context:
     # the Android project folder where everything ends up
     dist_dir = None
 
-    # where Android libs are cached after build
-    # but before being placed in dists
-    libs_dir = None
-    aars_dir = None
-
     # Whether setup.py or similar should be used if present:
     use_setup_py = False
 
@@ -109,6 +104,10 @@ class Context:
 
     @property
     def libs_dir(self):
+        """
+        where Android libs are cached after build
+        but before being placed in dists
+        """
         # Was previously hardcoded as self.build_dir/libs
         directory = join(self.build_dir, 'libs_collections',
                          self.bootstrap.distribution.name)

--- a/pythonforandroid/graph.py
+++ b/pythonforandroid/graph.py
@@ -45,7 +45,7 @@ def get_dependency_tuple_list_for_recipe(recipe, blacklist=None):
     """
     if blacklist is None:
         blacklist = set()
-    assert type(blacklist) == set
+    assert type(blacklist) is set
     if recipe.depends is None:
         dependencies = []
     else:
@@ -160,7 +160,7 @@ def obvious_conflict_checker(ctx, name_tuples, blacklist=None):
         current_to_be_added = list(to_be_added)
         to_be_added = []
         for (added_tuple, adding_recipe) in current_to_be_added:
-            assert type(added_tuple) == tuple
+            assert type(added_tuple) is tuple
             if len(added_tuple) > 1:
                 # No obvious commitment in what to add, don't check it itself
                 # but throw it into deps for later comparing against

--- a/pythonforandroid/toolchain.py
+++ b/pythonforandroid/toolchain.py
@@ -997,7 +997,7 @@ class ToolchainCL:
         fix_args = ('--dir', '--private', '--add-jar', '--add-source',
                     '--whitelist', '--blacklist', '--presplash', '--icon',
                     '--icon-bg', '--icon-fg', '--fileprovider-paths',
-                    '--google-services-json')
+                    '--google-services-json', '--res-values')
         unknown_args = args.unknown_args
 
         for asset in args.assets:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -36,10 +36,10 @@ class TestBuildBasic(unittest.TestCase):
         modules = ["mymodule"]
         project_dir = None
         with mock.patch('pythonforandroid.build.info'), \
-                mock.patch('sh.Command'),\
-                mock.patch('pythonforandroid.build.open'),\
-                mock.patch('pythonforandroid.build.shprint'),\
-                mock.patch('pythonforandroid.build.current_directory'),\
+                mock.patch('sh.Command'), \
+                mock.patch('pythonforandroid.build.open'), \
+                mock.patch('pythonforandroid.build.shprint'), \
+                mock.patch('pythonforandroid.build.current_directory'), \
                 mock.patch('pythonforandroid.build.CythonRecipe') as m_CythonRecipe, \
                 mock.patch('pythonforandroid.build.project_has_setup_py') as m_project_has_setup_py, \
                 mock.patch('pythonforandroid.build.run_setuppy_install'):


### PR DESCRIPTION
Add the --res-values options to specify resource value files to copy to `src/main/res/values` in the dist directory. This allows customizing `styles.xml` and `colors.xml`, for example.